### PR TITLE
Introducing beta auto-updater

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,4 +1,12 @@
-<Application x:Class="TFT_Overlay.App" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:local="clr-namespace:TFT_Overlay" StartupUri="MainWindow.xaml" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" d1p1:Ignorable="d" xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006">
+<Application x:Class="TFT_Overlay.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:TFT_Overlay"
+             Startup="AutoUpdater"
+             StartupUri="MainWindow.xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             d1p1:Ignorable="d"
+             xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006">
     <Application.Resources>
         <ResourceDictionary>
             <vm:ViewModelLocator x:Key="Locator" d:IsDataSource="True" xmlns:vm="clr-namespace:TFT_Overlay.ViewModel" />

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -5,13 +5,35 @@ using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Net;
 
 namespace TFT_Overlay
 {
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
+
     public partial class App : Application
     {
+
+        void AutoUpdater(object sender, StartupEventArgs e)
+        {
+            string currentVersion = "1.7.2";
+            string version;
+
+            using (WebClient client = new WebClient())
+            {
+                string htmlCode = client.DownloadString("https://raw.githubusercontent.com/Just2good/TFT-Overlay/master/MainWindow.xaml.cs");
+                int versionFind = htmlCode.IndexOf("TFT Information Overlay");
+                version = htmlCode.Substring(versionFind + 25, 5);
+
+                if (currentVersion != version)
+                {
+
+                    System.Windows.Forms.MessageBox.Show("New version downloading to local directory, please unzip and run.");
+                    string link = "https://github.com/Just2good/TFT-Overlay/releases/download/V" + version + "/TFT.Overlay.V" + version + ".rar";
+                    ServicePointManager.Expect100Continue = true;
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                    client.DownloadFile(new Uri(link), "TFT.rar");
+                }
+            }
+        }
     }
 }

--- a/TFT Overlay.csproj
+++ b/TFT Overlay.csproj
@@ -104,6 +104,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Current flow:

- On startup, checks if a newer version exists
- If exists, download to current working working directory
- Inform user that it exists, and to unzip it

Potential:
- Can force exit and unzip, replace files
    - Issue is this might be too aggressive, thoughts?
- If accepted, can create a better version checker instead of having to go through `MainWindow.xaml.cs`

Increased upkeep:
- For now requires you update `App.xaml.cs` with new versions, but I'll remove that and just use MainWindow once I figure out scoping more

To test it out now, simply change line 18 in `App.xaml.cs` to anything else really, such as `1.7.1`.
Build, and run. If it wasn't changed, then nothing happens and users can just keep using it.