### PR TITLE
Polished autoupdater

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="TFT_Overlay.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
     </startup>
+
+    <userSettings>
+        <TFT_Overlay.Properties.Settings>
+            <setting name="AutoUpdate" serializeAs="String">
+                <value>True</value>
+            </setting>
+        </TFT_Overlay.Properties.Settings>
+    </userSettings>
 </configuration>

--- a/App.xaml
+++ b/App.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:TFT_Overlay"         
              StartupUri="MainWindow.xaml"
+             Startup="AutoUpdater"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              d1p1:Ignorable="d"
              xmlns:d1p1="http://schemas.openxmlformats.org/markup-compatibility/2006">

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -6,34 +6,44 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Net;
+using System.Windows.Forms;
 
 namespace TFT_Overlay
 {
-    
-    public partial class App : Application
+
+    public partial class App : System.Windows.Application
     {
 
-      /*  void AutoUpdater(object sender, StartupEventArgs e)
+        void AutoUpdater(object sender, StartupEventArgs e)
         {
-            string currentVersion = "1.8.";
+            string currentVersion = "1.8.1";
             string version;
+            
 
             using (WebClient client = new WebClient())
             {
                 string htmlCode = client.DownloadString("https://raw.githubusercontent.com/Just2good/TFT-Overlay/master/MainWindow.xaml.cs");
                 int versionFind = htmlCode.IndexOf("TFT Information Overlay");
                 version = htmlCode.Substring(versionFind + 25, 5);
-
-                if (currentVersion != version)
+                if (currentVersion != version && TFT_Overlay.Properties.Settings.Default.AutoUpdate)
                 {
+                    DialogResult result = System.Windows.Forms.MessageBox.Show("New update available, would you like to download it?", "Confirmation", MessageBoxButtons.YesNo);
 
-                    System.Windows.Forms.MessageBox.Show("New version downloading to local directory, please unzip and run.");
-                    string link = "https://github.com/Just2good/TFT-Overlay/releases/download/V" + version + "/TFT.Overlay.V" + version + ".rar";
-                    ServicePointManager.Expect100Continue = true;
-                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-                    client.DownloadFile(new Uri(link), "TFT.rar");
+                    if (result == DialogResult.Yes)
+                    {
+                        System.Windows.Forms.MessageBox.Show("The zip file was downloaded to your local directory, please extract and use the updated version instead.", "Downloaded");
+                        string link = "https://github.com/Just2good/TFT-Overlay/releases/download/V" + version + "/TFT.Overlay.V" + version + ".rar";
+                        ServicePointManager.Expect100Continue = true;
+                        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+                        client.DownloadFile(new Uri(link), "TFT.rar");
+                    }
+                    else if (result == DialogResult.No)
+                    {
+                        TFT_Overlay.Properties.Settings.Default.AutoUpdate = false;
+                        TFT_Overlay.Properties.Settings.Default.Save();
+                    }
                 }
             }
-        } */
+        }
     }
 }

--- a/DialogBox.cs
+++ b/DialogBox.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace TFT_Overlay
+{
+    class DialogBox
+    {
+
+        public static DialogResult dialogInit(string title, string promptText, string button1 = "OK", string button2 = "Cancel", string button3 = null)
+        {
+            Form form = new Form();
+            Label label = new Label();
+            TextBox textBox = new TextBox();
+            Button button_1 = new Button();
+            Button button_2 = new Button();
+            Button button_3 = new Button();
+
+            int buttonStartPos = 228; //Standard two button position
+
+
+            if (button3 != null)
+                buttonStartPos = 228 - 81;
+            else
+            {
+                button_3.Visible = false;
+                button_3.Enabled = false;
+            }
+
+
+            form.Text = title;
+
+            // Label
+            label.Text = promptText;
+            label.SetBounds(9, 20, 372, 13);
+            label.Font = new Font("Microsoft Tai Le", 12, FontStyle.Regular);
+
+            // TextBox
+            string value = null;
+            if (value == null)
+            {
+            }
+            else
+            {
+                textBox.Text = value;
+                textBox.SetBounds(12, 36, 372, 20);
+                textBox.Anchor = textBox.Anchor | AnchorStyles.Right;
+            }
+
+            button_1.Text = button1;
+            button_2.Text = button2;
+            button_3.Text = button3 ?? string.Empty;
+            button_1.DialogResult = DialogResult.OK;
+            button_2.DialogResult = DialogResult.Cancel;
+            button_3.DialogResult = DialogResult.Yes;
+
+
+            button_1.SetBounds(buttonStartPos, 72, 75, 23);
+            button_2.SetBounds(buttonStartPos + 81, 72, 75, 23);
+            button_3.SetBounds(buttonStartPos + (2 * 81), 72, 75, 23);
+
+            label.AutoSize = true;
+            button_1.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            button_2.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            button_3.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+
+            form.ClientSize = new Size(396, 107);
+            form.Controls.AddRange(new Control[] { label, button_1, button_2 });
+            if (button3 != null)
+                form.Controls.Add(button_3);
+            if (value != null)
+                form.Controls.Add(textBox);
+
+            form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+            form.FormBorderStyle = FormBorderStyle.FixedDialog;
+            form.StartPosition = FormStartPosition.CenterScreen;
+            form.MinimizeBox = false;
+            form.MaximizeBox = false;
+            form.AcceptButton = button_1;
+            form.CancelButton = button_2;
+
+            DialogResult dialogResult = form.ShowDialog();
+            value = textBox.Text;
+            return dialogResult;
+        }
+    }
+}

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,8 +12,8 @@ namespace TFT_Overlay.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "12.0.0.0")]
+    public sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
         
@@ -25,13 +25,13 @@ namespace TFT_Overlay.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string Setting {
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool AutoUpdate {
             get {
-                return ((string)(this["Setting"]));
+                return ((bool)(this["AutoUpdate"]));
             }
             set {
-                this["Setting"] = value;
+                this["AutoUpdate"] = value;
             }
         }
     }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -1,7 +1,9 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="uri:settings" CurrentProfile="(Default)">
-  <Profiles>
-    <Profile Name="(Default)" />
-  </Profiles>
-  <Settings />
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="TFT_Overlay.Properties" GeneratedClassName="Settings">
+  <Profiles />
+  <Settings>
+    <Setting Name="AutoUpdate" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
+  </Settings>
 </SettingsFile>

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,0 +1,28 @@
+﻿namespace TFT_Overlay.Properties {
+    
+    
+    // This class allows you to handle specific events on the settings class:
+    //  The SettingChanging event is raised before a setting's value is changed.
+    //  The PropertyChanged event is raised after a setting's value is changed.
+    //  The SettingsLoaded event is raised after the setting values are loaded.
+    //  The SettingsSaving event is raised before the setting values are saved.
+    public sealed partial class Settings {
+        
+        public Settings() {
+            // // To add event handlers for saving and changing settings, uncomment the lines below:
+            //
+            // this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            // this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // Add code to handle the SettingChangingEvent event here.
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // Add code to handle the SettingsSaving event here.
+        }
+    }
+}

--- a/TFT Overlay.csproj
+++ b/TFT Overlay.csproj
@@ -127,7 +127,9 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="DialogBox.cs" />
     <Compile Include="RadioConverter.cs" />
+    <Compile Include="Settings.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />
     <Compile Include="ViewModel\ViewModelLocator.cs" />
     <Page Include="MainWindow.xaml">
@@ -184,7 +186,7 @@
     <Resource Include="Font\Cabin-SemiBoldItalic.ttf" />
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
+      <Generator>PublicSettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>


### PR DESCRIPTION
Now has a a Yes/No dialogue option.
`Yes` downloads the zip to `cwd`, while `No` should never show the message box again.

Any idea why you got asked ∞ times to download the new update? Also, how does scope for partial classes work? Can I get the value of a string from `MainWindow` to `App`?