### PR TITLE
Adding autohide when TFT not active window

### DIFF
--- a/App.config
+++ b/App.config
@@ -14,6 +14,9 @@
             <setting name="AutoUpdate" serializeAs="String">
                 <value>True</value>
             </setting>
+          <setting name="AutoHide" serializeAs="String">
+            <value>False</value>
+          </setting>
         </TFT_Overlay.Properties.Settings>
     </userSettings>
 </configuration>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -28,14 +29,19 @@ namespace TFT_Overlay
         
         bool onTop = true;
         bool canDrag = true;
+        bool isVisible = true;
         string currentVersion = Version.version;
 
         public MainWindow()
         {
             InitializeComponent();
             MouseLeftButtonDown += new MouseButtonEventHandler(MainWindow_MouseLeftButtonDown);
-        }
 
+            if (Properties.Settings.Default.AutoHide)
+            {
+                new Thread(new ThreadStart(AutoHide)).Start();
+            }
+        }
 
         private void MenuItem_Click(object sender, RoutedEventArgs e)
         {
@@ -85,6 +91,31 @@ namespace TFT_Overlay
             {
                 this.DragMove();
             }
+        }
+
+        private void AutoHide()
+        {
+            while (true)
+            {
+                if (IsLeagueOrOverlayActive() && !isVisible)
+                {
+                    Dispatcher.BeginInvoke(new ThreadStart(() => App.Current.MainWindow.Show()));
+                    isVisible = true;
+                }
+                else if (!IsLeagueOrOverlayActive() && isVisible)
+                {
+                    Dispatcher.BeginInvoke(new ThreadStart(() => App.Current.MainWindow.Hide()));
+                    isVisible = false;
+                }
+
+                Thread.Sleep(100);
+            }
+        }
+
+        private static bool IsLeagueOrOverlayActive()
+        {
+            var currentActiveProcessName = ProcessHelper.GetActiveProcessName();
+            return currentActiveProcessName == "League of Legends" || currentActiveProcessName == "TFT Overlay";
         }
     }
 }

--- a/ProcessHelper.cs
+++ b/ProcessHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace TFT_Overlay
+{
+    public static class ProcessHelper
+    {
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetWindowThreadProcessId(IntPtr hWnd, out uint ProcessId);
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr GetForegroundWindow();
+
+        public static string GetActiveProcessName()
+        {
+            var hwnd = GetForegroundWindow();
+            GetWindowThreadProcessId(hwnd, out uint pid);
+
+            return Process.GetProcessById((int)pid).ProcessName;
+        }
+    }
+}

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -34,5 +34,20 @@ namespace TFT_Overlay.Properties {
                 this["AutoUpdate"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool AutoHide
+        {
+            get
+            {
+                return ((bool)(this["AutoHide"]));
+            }
+            set
+            {
+                this["AutoHide"] = value;
+            }
+        }
     }
 }

--- a/TFT Overlay.csproj
+++ b/TFT Overlay.csproj
@@ -129,6 +129,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="ProcessHelper.cs" />
     <Compile Include="RadioConverter.cs" />
     <Compile Include="Settings.cs" />
     <Compile Include="Version.cs" />


### PR DESCRIPTION
Adds a new config item called AutoHide which defaults to false (preserves current behaviour), when set to True, it auto hides the overlay when the TFT client isn't the current active window, and shows it again when the TFT client is active again.